### PR TITLE
OSX fixes and stylistic improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.o
+glfwStarterProjectBin

--- a/Cube.h
+++ b/Cube.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include <GL/glew.h>
+#ifdef __APPLE__
 #include <OpenGL/gl3.h>
+#else
+#include <OpenGL/gl.h>
+#endif /* __APPLE__ */
 #include <OpenGL/glext.h>
 
 

--- a/Cube.h
+++ b/Cube.h
@@ -1,13 +1,10 @@
 #ifndef _CUBE_H_
 #define _CUBE_H_
 
-#ifdef __APPLE__
-// If modern OpenGL replace gl.h with gl3.h
-#include <OpenGL/gl.h>
-#include <OpenGL/glext.h>
-#else
 #include <GL/glew.h>
-#endif
+#include <OpenGL/gl3.h>
+#include <OpenGL/glext.h>
+
 
 #include <GLFW/glfw3.h>
 #include <glm/mat4x4.hpp>

--- a/Cube.h
+++ b/Cube.h
@@ -1,5 +1,4 @@
-#ifndef _CUBE_H_
-#define _CUBE_H_
+#pragma once
 
 #include <GL/glew.h>
 #include <OpenGL/gl3.h>
@@ -26,6 +25,3 @@ public:
 
 	void spin(float);
 };
-
-#endif
-

--- a/Cube.h
+++ b/Cube.h
@@ -1,15 +1,7 @@
 #pragma once
 
-#include <GL/glew.h>
-#ifdef __APPLE__
-#include <OpenGL/gl3.h>
-#else
-#include <OpenGL/gl.h>
-#endif /* __APPLE__ */
-#include <OpenGL/glext.h>
+#include "gl-inl.h"
 
-
-#include <GLFW/glfw3.h>
 #include <glm/mat4x4.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,15 @@ RM = /bin/rm -f
 .PHONY: all
 all: glfwStarterProjectBin
 
-glfwStarterProjectBin: main.o Window.o Cube.o
+glfwStarterProjectBin: main.o Window.o Cube.o OBJObject.o
 	$(CC) $(CFLAGS) -o glfwStarterProjectBin main.o Window.o Cube.o $(INCFLAGS) $(LDFLAGS)
-main.o: Window.o main.cpp main.h
+main.o: Window.o main.cpp gl-inl.h
 	$(CC) $(CFLAGS) $(INCFLAGS) -c main.cpp
-Window.o: Cube.o Window.cpp Window.h
+Window.o: Cube.o Window.cpp Window.h gl-inl.h
 	$(CC) $(CFLAGS) $(INCFLAGS) -c Window.cpp
-Cube.o: Cube.cpp Cube.h
+Cube.o: Cube.cpp Cube.h gl-inl.h
 	$(CC) $(CFLAGS) $(INCFLAGS) -c Cube.cpp
+OBJObject.o: OBJObject.h gl-inl.h
+	$(CC) $(CFLAGS) $(INCFLAGS) -c OBJObject.cpp
 clean:
 	$(RM) *.o glfwStarterProjectBin

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,20 @@
-CFLAGS = -g -DGL_GLEXT_PROTOTYPES -DGL_DO_NOT_WARN_IF_MULTI_GL_VERSION_HEADERS_INCLUDED -DOSX
+CFLAGS = -g --std=c++14 -DGL_GLEXT_PROTOTYPES -DGL_DO_NOT_WARN_IF_MULTI_GL_VERSION_HEADERS_INCLUDED
 GLCCFLAGS := `pkg-config --cflags glfw3 glm glew`
 GLLDFLAGS := `pkg-config --libs glfw3 glm glew`
 INCFLAGS = -I/usr/X11/include $(GLCCFLAGS)
-LDFLAGS = -framework Cocoa -framework OpenGL -framework IOKit -framework CoreVideo \
-		-L"/System/Library/Frameworks/OpenGL.framework/Libraries" \
-		-lGL -lstdc++ $(GLLDFLAGS)
+LDFLAGS = -lGL -lstdc++ $(GLLDFLAGS)
 
 RM = /bin/rm -f
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+endif
+ifeq ($(UNAME_S),Darwin)
+	LDFLAGS += \
+		-framework Cocoa -framework OpenGL -framework IOKit -framework CoreVideo \
+		-L"/System/Library/Frameworks/OpenGL.framework/Libraries"
+endif
+
 
 .PHONY: all
 all: glfwStarterProjectBin

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,18 @@
-#NOTE: This makefile doesn't actually work. Use/Modify it at your own risk!
-CC = g++
-#Makefile flags for OSX devices
-ifeq ($(shell sw_vers 2>/dev/null | grep Mac | awk '{ print $$2}'),Mac)
-CFLAGS = -g -DGL_GLEXT_PROTOTYPES -DGL_DO_NOT_WARN_IF_MULTI_GL_VERSION_HEADERS_INCLUDED -DOSX -Wno-deprecated-register -Wno-deprecated-declarations -Wno-shift-op-parentheses -Wno-parentheses-equality
-INCFLAGS = -I./glm-0.9.7.1 -I/usr/X11/include -I./include/
-LDFLAGS = -framework Cocoa -framework OpenGL -framework IOKit -framework CoreVideo -L./lib/mac/ \
+CFLAGS = -g -DGL_GLEXT_PROTOTYPES -DGL_DO_NOT_WARN_IF_MULTI_GL_VERSION_HEADERS_INCLUDED -DOSX
+GLCCFLAGS := `pkg-config --cflags glfw3 glm glew`
+GLLDFLAGS := `pkg-config --libs glfw3 glm glew`
+INCFLAGS = -I/usr/X11/include $(GLCCFLAGS)
+LDFLAGS = -framework Cocoa -framework OpenGL -framework IOKit -framework CoreVideo \
 		-L"/System/Library/Frameworks/OpenGL.framework/Libraries" \
-		-lGL -lGLU -lm -lglfw3 -lstdc++
-#Makefile flags for Unix devices
-else
-#TODO
-endif
+		-lGL -lstdc++ $(GLLDFLAGS)
+
 RM = /bin/rm -f
-all: glfwStarterProject
-glfwStarterProject: main.o Window.o Cube.o
-	$(CC) $(CFLAGS) -o glfwStarterProject main.o Window.o Cube.o $(INCFLAGS) $(LDFLAGS)
+
+.PHONY: all
+all: glfwStarterProjectBin
+
+glfwStarterProjectBin: main.o Window.o Cube.o
+	$(CC) $(CFLAGS) -o glfwStarterProjectBin main.o Window.o Cube.o $(INCFLAGS) $(LDFLAGS)
 main.o: Window.o main.cpp main.h
 	$(CC) $(CFLAGS) $(INCFLAGS) -c main.cpp
 Window.o: Cube.o Window.cpp Window.h
@@ -22,4 +20,4 @@ Window.o: Cube.o Window.cpp Window.h
 Cube.o: Cube.cpp Cube.h
 	$(CC) $(CFLAGS) $(INCFLAGS) -c Cube.cpp
 clean:
-	$(RM) *.o glfwStarterProject
+	$(RM) *.o glfwStarterProjectBin

--- a/OBJObject.cpp
+++ b/OBJObject.cpp
@@ -1,18 +1,18 @@
 #include "OBJObject.h"
 
-OBJObject::OBJObject(const char *filepath) 
+OBJObject::OBJObject(std::string const& filepath)
 {
 	toWorld = glm::mat4(1.0f);
 	parse(filepath);
 }
 
-void OBJObject::parse(const char *filepath) 
+void OBJObject::parse(std::string const& filepath)
 {
 	//TODO parse the OBJ file
 	// Populate the face indices, vertices, and normals vectors with the OBJ Object data
 }
 
-void OBJObject::draw() 
+void OBJObject::draw()
 {
 	glMatrixMode(GL_MODELVIEW);
 
@@ -22,7 +22,7 @@ void OBJObject::draw()
 
 	glBegin(GL_POINTS);
 	// Loop through all the vertices of this OBJ Object and render them
-	for (unsigned int i = 0; i < vertices.size(); ++i) 
+	for (unsigned int i = 0; i < vertices.size(); ++i)
 	{
 		glVertex3f(vertices[i].x, vertices[i].y, vertices[i].z);
 	}

--- a/OBJObject.h
+++ b/OBJObject.h
@@ -5,18 +5,18 @@
 #include <glm/mat4x4.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <vector>
+#include <string>
 
 class OBJObject
 {
-private:
-std::vector<unsigned int> indices;
-std::vector<glm::vec3> vertices;
-std::vector<glm::vec3> normals;
-glm::mat4 toWorld;
+	std::vector<unsigned int> indices;
+	std::vector<glm::vec3> vertices;
+	std::vector<glm::vec3> normals;
+	glm::mat4 toWorld;
 
 public:
-	OBJObject(const char* filepath);
+	OBJObject(std::string const& filepath);
 
-	void parse(const char* filepath);
+	void parse(std::string const& filepath);
 	void draw();
 };

--- a/OBJObject.h
+++ b/OBJObject.h
@@ -1,11 +1,8 @@
 #pragma once
 
+#include <GL/glew.h>
 #include <OpenGL/gl3.h>
 #include <OpenGL/glext.h>
-#include <OpenGL/gl.h> // Remove this line in future projects
-#else
-#include <GL/glew.h>
-#endif
 
 #include <GLFW/glfw3.h>
 #include <glm/mat4x4.hpp>

--- a/OBJObject.h
+++ b/OBJObject.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include <GL/glew.h>
+#ifdef __APPLE__
 #include <OpenGL/gl3.h>
+#else
+#include <OpenGL/gl.h>
+#endif /* __APPLE__ */
 #include <OpenGL/glext.h>
 
 #include <GLFW/glfw3.h>

--- a/OBJObject.h
+++ b/OBJObject.h
@@ -1,7 +1,5 @@
-#ifndef OBJOBJECT_H
-#define OBJOBJECT_H
+#pragma once
 
-#ifdef __APPLE__
 #include <OpenGL/gl3.h>
 #include <OpenGL/glext.h>
 #include <OpenGL/gl.h> // Remove this line in future projects
@@ -28,5 +26,3 @@ public:
 	void parse(const char* filepath);
 	void draw();
 };
-
-#endif

--- a/OBJObject.h
+++ b/OBJObject.h
@@ -1,14 +1,7 @@
 #pragma once
 
-#include <GL/glew.h>
-#ifdef __APPLE__
-#include <OpenGL/gl3.h>
-#else
-#include <OpenGL/gl.h>
-#endif /* __APPLE__ */
-#include <OpenGL/glext.h>
+#include "gl-inl.h"
 
-#include <GLFW/glfw3.h>
 #include <glm/mat4x4.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <vector>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+Ubuntu/Debian usage:
+------
+```
+$ sudo apt-get install libglew-dev mesa-common-dev libglfw3-dev libglm-dev
+$ make
+```
+
+Mac usage:
+------
+```
+$ brew install glfw3 glm glew
+$ make
+```

--- a/Rasterizer.cpp
+++ b/Rasterizer.cpp
@@ -101,7 +101,7 @@ int main(int argc, char** argv) {
 	glfwWindowHint(GLFW_SAMPLES, 4);
 
 	// Create the GLFW window
-	GLFWwindow* window = glfwCreateWindow(window_height, window_height, "Rastizer", NULL, NULL);
+	GLFWwindow* window = glfwCreateWindow(window_height, window_height, "Rastizer", nullptr, nullptr);
 
 	// Check if the window could not be created
 	if (!window)

--- a/Rasterizer.cpp
+++ b/Rasterizer.cpp
@@ -86,14 +86,14 @@ void displayCallback(GLFWwindow* window)
 void errorCallback(int error, const char* description)
 {
 	// Print error
-	fputs(description, stderr);
+	std::cerr << description << std::endl;
 }
 
 int main(int argc, char** argv) {
 	// Initialize GLFW
 	if (!glfwInit())
 	{
-		fprintf(stderr, "Failed to initialize GLFW\n");
+		std::cerr << "Failed to initialize GLFW" << std::endl;
 		return -1;
 	}
 
@@ -106,7 +106,7 @@ int main(int argc, char** argv) {
 	// Check if the window could not be created
 	if (!window)
 	{
-		fprintf(stderr, "Failed to open GLFW window.\n");
+		std::cerr << "Failed to open GLFW window." << std::endl;
 		glfwTerminate();
 		return -1;
 	}

--- a/Window.cpp
+++ b/Window.cpp
@@ -44,7 +44,9 @@ GLFWwindow* Window::create_window(int width, int height)
 	glfwSwapInterval(1);
 
 	// Call the resize callback to make sure things get drawn immediately
-	Window::resize_callback(window, width, height);
+	int fwidth, fheight;
+	glfwGetFramebufferSize(window, &fwidth, &fheight);
+	Window::resize_callback(window, fwidth, fheight);
 
 	return window;
 }
@@ -79,7 +81,7 @@ void Window::display_callback(GLFWwindow* window)
 	glMatrixMode(GL_MODELVIEW);
 	// Load the identity matrix
 	glLoadIdentity();
-	
+
 	// Render objects
 	cube.draw();
 

--- a/Window.cpp
+++ b/Window.cpp
@@ -1,6 +1,7 @@
 #include "Window.h"
 
 #include <string>
+#include <iostream>
 
 const std::string window_title = "GLFW Starter Project";
 Cube cube(5.0f);
@@ -21,22 +22,22 @@ GLFWwindow* Window::create_window(int width, int height)
 	// Initialize GLFW.
 	if (!glfwInit())
 	{
-		fprintf(stderr, "Failed to initialize GLFW\n");
-		return NULL;
+		std::cerr << "Failed to initialize GLFW" << std::endl;
+		return nullptr;
 	}
 
 	// 4x antialiasing
 	glfwWindowHint(GLFW_SAMPLES, 4);
 
 	// Create the GLFW window
-	GLFWwindow* window = glfwCreateWindow(width, height, window_title.c_str(), NULL, NULL);
+	GLFWwindow* window = glfwCreateWindow(width, height, window_title.c_str(), nullptr, nullptr);
 
 	// Check if the window could not be created
 	if (!window)
 	{
-		fprintf(stderr, "Failed to open GLFW window.\n");
+		std::cerr << "Failed to open GLFW window" << std::endl;
 		glfwTerminate();
-		return NULL;
+		return nullptr;
 	}
 
 	// Make the context of the window

--- a/Window.cpp
+++ b/Window.cpp
@@ -1,6 +1,8 @@
 #include "Window.h"
 
-const char* window_title = "GLFW Starter Project";
+#include <string>
+
+const std::string window_title = "GLFW Starter Project";
 Cube cube(5.0f);
 
 int Window::width;
@@ -27,7 +29,7 @@ GLFWwindow* Window::create_window(int width, int height)
 	glfwWindowHint(GLFW_SAMPLES, 4);
 
 	// Create the GLFW window
-	GLFWwindow* window = glfwCreateWindow(width, height, window_title, NULL, NULL);
+	GLFWwindow* window = glfwCreateWindow(width, height, window_title.c_str(), NULL, NULL);
 
 	// Check if the window could not be created
 	if (!window)

--- a/Window.h
+++ b/Window.h
@@ -3,13 +3,9 @@
 
 #include <iostream>
 
-#ifdef __APPLE__
-// If modern OpenGL replace gl.h with gl3.h
-#include <OpenGL/gl.h>
-#include <OpenGL/glext.h>
-#else
 #include <GL/glew.h>
-#endif
+#include <OpenGL/gl3.h>
+#include <OpenGL/glext.h>
 
 #include <GLFW/glfw3.h>
 #include "Cube.h"

--- a/Window.h
+++ b/Window.h
@@ -3,7 +3,11 @@
 #include <iostream>
 
 #include <GL/glew.h>
+#ifdef __APPLE__
 #include <OpenGL/gl3.h>
+#else
+#include <OpenGL/gl.h>
+#endif /* __APPLE__ */
 #include <OpenGL/glext.h>
 
 #include <GLFW/glfw3.h>

--- a/Window.h
+++ b/Window.h
@@ -1,5 +1,4 @@
-#ifndef _WINDOW_H_
-#define _WINDOW_H_
+#pragma once
 
 #include <iostream>
 
@@ -23,5 +22,3 @@ public:
 	static void display_callback(GLFWwindow*);
 	static void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods);
 };
-
-#endif

--- a/Window.h
+++ b/Window.h
@@ -2,15 +2,7 @@
 
 #include <iostream>
 
-#include <GL/glew.h>
-#ifdef __APPLE__
-#include <OpenGL/gl3.h>
-#else
-#include <OpenGL/gl.h>
-#endif /* __APPLE__ */
-#include <OpenGL/glext.h>
-
-#include <GLFW/glfw3.h>
+#include "gl-inl.h"
 #include "Cube.h"
 
 class Window

--- a/gl-inl.h
+++ b/gl-inl.h
@@ -3,9 +3,10 @@
 #include <GL/glew.h>
 #ifdef __APPLE__
 #include <OpenGL/gl3.h>
-#else
-#include <OpenGL/gl.h>
-#endif /* __APPLE__ */
 #include <OpenGL/glext.h>
+#else
+#include <GL/gl.h>
+#include <GL/glext.h>
+#endif /* __APPLE__ */
 
 #include <GLFW/glfw3.h>

--- a/gl-inl.h
+++ b/gl-inl.h
@@ -9,6 +9,3 @@
 #include <OpenGL/glext.h>
 
 #include <GLFW/glfw3.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include "Window.h"

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,4 @@
 #include <stdlib.h>
-#include <stdio.h>
 
 #include "gl-inl.h"
 #include "Window.h"
@@ -7,7 +6,7 @@
 void error_callback(int error, const char* description)
 {
 	// Print error
-	fputs(description, stderr);
+	std::cerr << description << std::endl;
 }
 
 void setup_callbacks(GLFWwindow* window)
@@ -74,12 +73,12 @@ void setup_opengl_settings()
 void print_versions()
 {
 	// Get info of GPU and supported OpenGL version
-	printf("Renderer: %s\n", glGetString(GL_RENDERER));
-	printf("OpenGL version supported %s\n", glGetString(GL_VERSION));
+	std::cout << "Renderer: " << glGetString(GL_RENDERER) << std::endl;
+	std::cout << "OpenGL version supported " << glGetString(GL_VERSION) << std::endl;
 
 	//If the shading language symbol is defined
 #ifdef GL_SHADING_LANGUAGE_VERSION
-	std::printf("Supported GLSL version is %s.\n", (char *)glGetString(GL_SHADING_LANGUAGE_VERSION));
+	std::cout << "Supported GLSL version is " << glGetString(GL_SHADING_LANGUAGE_VERSION) << std::endl;
 #endif
 }
 
@@ -111,5 +110,5 @@ int main(void)
 	// Terminate GLFW
 	glfwTerminate();
 
-	exit(EXIT_SUCCESS);
+	return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1,14 +1,12 @@
 #include "main.h"
 
-GLFWwindow* window;
-
 void error_callback(int error, const char* description)
 {
 	// Print error
 	fputs(description, stderr);
 }
 
-void setup_callbacks()
+void setup_callbacks(GLFWwindow* window)
 {
 	// Set the error callback
 	glfwSetErrorCallback(error_callback);
@@ -57,16 +55,16 @@ void setup_opengl_settings()
 	// Disable backface culling to render both sides of polygons
 	glDisable(GL_CULL_FACE);
 	// Set clear color to black
-	glClearColor(0.0, 0.0, 0.0, 0.0);                           
+	glClearColor(0.0, 0.0, 0.0, 0.0);
 	// Set shading to smooth
-	glShadeModel(GL_SMOOTH);                                    
+	glShadeModel(GL_SMOOTH);
 	// Auto normalize surface normals
 	glEnable(GL_NORMALIZE);
-	
+
 	// Setup materials
 	setup_materials();
 	// Setup lighting
-	setup_lighting();                                           
+	setup_lighting();
 }
 
 void print_versions()
@@ -84,11 +82,11 @@ void print_versions()
 int main(void)
 {
 	// Create the GLFW window
-	window = Window::create_window(640, 480);
+	GLFWwindow* window = Window::create_window(640, 480);
 	// Print OpenGL and GLSL versions
 	print_versions();
 	// Setup callbacks
-	setup_callbacks();
+	setup_callbacks(window);
 	// Setup OpenGL settings, including lighting, materials, etc.
 	setup_opengl_settings();
 	// Initialize objects/pointers for rendering

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,8 @@
-#include "main.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "gl-inl.h"
+#include "Window.h"
 
 void error_callback(int error, const char* description)
 {

--- a/main.cpp
+++ b/main.cpp
@@ -13,7 +13,7 @@ void setup_callbacks(GLFWwindow* window)
 	// Set the key callback
 	glfwSetKeyCallback(window, Window::key_callback);
 	// Set the window resize callback
-	glfwSetWindowSizeCallback(window, Window::resize_callback);
+	glfwSetFramebufferSizeCallback(window, Window::resize_callback);
 }
 
 void setup_materials()

--- a/main.h
+++ b/main.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include <GL/glew.h>
+#ifdef __APPLE__
 #include <OpenGL/gl3.h>
+#else
+#include <OpenGL/gl.h>
+#endif /* __APPLE__ */
 #include <OpenGL/glext.h>
 
 #include <GLFW/glfw3.h>

--- a/main.h
+++ b/main.h
@@ -1,5 +1,4 @@
-#ifndef _MAIN_H_
-#define _MAIN_H_
+#pragma once
 
 #include <GL/glew.h>
 #include <OpenGL/gl3.h>
@@ -9,5 +8,3 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "Window.h"
-
-#endif

--- a/main.h
+++ b/main.h
@@ -1,13 +1,10 @@
 #ifndef _MAIN_H_
 #define _MAIN_H_
 
-#ifdef __APPLE__
-// If modern OpenGL replace gl.h with gl3.h
-#include <OpenGL/gl.h>
-#include <OpenGL/glext.h>
-#else
 #include <GL/glew.h>
-#endif
+#include <OpenGL/gl3.h>
+#include <OpenGL/glext.h>
+
 #include <GLFW/glfw3.h>
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
Commit 1 & 4:
Provides a working `Makefile`, and unborks the include file set for OSX. In the future, rely on `pkg-config` for getting paths to dependencies. 

OSX users can use [brew](http://brew.sh/) (the standard 3rd party OSX package manager) to install dependencies with little hassle: 

``` sh
$ brew install glfw3 glew glm pkg-config
```

Commit 2: 
Style fixup, gets rid of a global var in `main.cpp` that doesn't have to exist, and pollutes the global namespace

Commit 3: 
`#pragma once` is supported by all major compilers, use that instead of hard to read guards. 
