### PR TITLE
Retina/high DPI display fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.o
+glfwStarterProjectBin

--- a/Cube.h
+++ b/Cube.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include <GL/glew.h>
+#ifdef __APPLE__
 #include <OpenGL/gl3.h>
+#else
+#include <OpenGL/gl.h>
+#endif /* __APPLE__ */
 #include <OpenGL/glext.h>
 
 

--- a/Cube.h
+++ b/Cube.h
@@ -1,13 +1,10 @@
 #ifndef _CUBE_H_
 #define _CUBE_H_
 
-#ifdef __APPLE__
-// If modern OpenGL replace gl.h with gl3.h
-#include <OpenGL/gl.h>
-#include <OpenGL/glext.h>
-#else
 #include <GL/glew.h>
-#endif
+#include <OpenGL/gl3.h>
+#include <OpenGL/glext.h>
+
 
 #include <GLFW/glfw3.h>
 #include <glm/mat4x4.hpp>

--- a/Cube.h
+++ b/Cube.h
@@ -1,5 +1,4 @@
-#ifndef _CUBE_H_
-#define _CUBE_H_
+#pragma once
 
 #include <GL/glew.h>
 #include <OpenGL/gl3.h>
@@ -26,6 +25,3 @@ public:
 
 	void spin(float);
 };
-
-#endif
-

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,18 @@
-#NOTE: This makefile doesn't actually work. Use/Modify it at your own risk!
-CC = g++
-#Makefile flags for OSX devices
-ifeq ($(shell sw_vers 2>/dev/null | grep Mac | awk '{ print $$2}'),Mac)
-CFLAGS = -g -DGL_GLEXT_PROTOTYPES -DGL_DO_NOT_WARN_IF_MULTI_GL_VERSION_HEADERS_INCLUDED -DOSX -Wno-deprecated-register -Wno-deprecated-declarations -Wno-shift-op-parentheses -Wno-parentheses-equality
-INCFLAGS = -I./glm-0.9.7.1 -I/usr/X11/include -I./include/
-LDFLAGS = -framework Cocoa -framework OpenGL -framework IOKit -framework CoreVideo -L./lib/mac/ \
+CFLAGS = -g -DGL_GLEXT_PROTOTYPES -DGL_DO_NOT_WARN_IF_MULTI_GL_VERSION_HEADERS_INCLUDED -DOSX
+GLCCFLAGS := `pkg-config --cflags glfw3 glm glew`
+GLLDFLAGS := `pkg-config --libs glfw3 glm glew`
+INCFLAGS = -I/usr/X11/include $(GLCCFLAGS)
+LDFLAGS = -framework Cocoa -framework OpenGL -framework IOKit -framework CoreVideo \
 		-L"/System/Library/Frameworks/OpenGL.framework/Libraries" \
-		-lGL -lGLU -lm -lglfw3 -lstdc++
-#Makefile flags for Unix devices
-else
-#TODO
-endif
+		-lGL -lstdc++ $(GLLDFLAGS)
+
 RM = /bin/rm -f
-all: glfwStarterProject
-glfwStarterProject: main.o Window.o Cube.o
-	$(CC) $(CFLAGS) -o glfwStarterProject main.o Window.o Cube.o $(INCFLAGS) $(LDFLAGS)
+
+.PHONY: all
+all: glfwStarterProjectBin
+
+glfwStarterProjectBin: main.o Window.o Cube.o
+	$(CC) $(CFLAGS) -o glfwStarterProjectBin main.o Window.o Cube.o $(INCFLAGS) $(LDFLAGS)
 main.o: Window.o main.cpp main.h
 	$(CC) $(CFLAGS) $(INCFLAGS) -c main.cpp
 Window.o: Cube.o Window.cpp Window.h
@@ -22,4 +20,4 @@ Window.o: Cube.o Window.cpp Window.h
 Cube.o: Cube.cpp Cube.h
 	$(CC) $(CFLAGS) $(INCFLAGS) -c Cube.cpp
 clean:
-	$(RM) *.o glfwStarterProject
+	$(RM) *.o glfwStarterProjectBin

--- a/OBJObject.h
+++ b/OBJObject.h
@@ -1,11 +1,8 @@
 #pragma once
 
+#include <GL/glew.h>
 #include <OpenGL/gl3.h>
 #include <OpenGL/glext.h>
-#include <OpenGL/gl.h> // Remove this line in future projects
-#else
-#include <GL/glew.h>
-#endif
 
 #include <GLFW/glfw3.h>
 #include <glm/mat4x4.hpp>

--- a/OBJObject.h
+++ b/OBJObject.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include <GL/glew.h>
+#ifdef __APPLE__
 #include <OpenGL/gl3.h>
+#else
+#include <OpenGL/gl.h>
+#endif /* __APPLE__ */
 #include <OpenGL/glext.h>
 
 #include <GLFW/glfw3.h>

--- a/OBJObject.h
+++ b/OBJObject.h
@@ -1,7 +1,5 @@
-#ifndef OBJOBJECT_H
-#define OBJOBJECT_H
+#pragma once
 
-#ifdef __APPLE__
 #include <OpenGL/gl3.h>
 #include <OpenGL/glext.h>
 #include <OpenGL/gl.h> // Remove this line in future projects
@@ -28,5 +26,3 @@ public:
 	void parse(const char* filepath);
 	void draw();
 };
-
-#endif

--- a/Window.cpp
+++ b/Window.cpp
@@ -44,7 +44,9 @@ GLFWwindow* Window::create_window(int width, int height)
 	glfwSwapInterval(1);
 
 	// Call the resize callback to make sure things get drawn immediately
-	Window::resize_callback(window, width, height);
+	int fwidth, fheight;
+	glfwGetFramebufferSize(window, &fwidth, &fheight);
+	Window::resize_callback(window, fwidth, fheight);
 
 	return window;
 }
@@ -79,7 +81,7 @@ void Window::display_callback(GLFWwindow* window)
 	glMatrixMode(GL_MODELVIEW);
 	// Load the identity matrix
 	glLoadIdentity();
-	
+
 	// Render objects
 	cube.draw();
 

--- a/Window.h
+++ b/Window.h
@@ -3,13 +3,9 @@
 
 #include <iostream>
 
-#ifdef __APPLE__
-// If modern OpenGL replace gl.h with gl3.h
-#include <OpenGL/gl.h>
-#include <OpenGL/glext.h>
-#else
 #include <GL/glew.h>
-#endif
+#include <OpenGL/gl3.h>
+#include <OpenGL/glext.h>
 
 #include <GLFW/glfw3.h>
 #include "Cube.h"

--- a/Window.h
+++ b/Window.h
@@ -3,7 +3,11 @@
 #include <iostream>
 
 #include <GL/glew.h>
+#ifdef __APPLE__
 #include <OpenGL/gl3.h>
+#else
+#include <OpenGL/gl.h>
+#endif /* __APPLE__ */
 #include <OpenGL/glext.h>
 
 #include <GLFW/glfw3.h>

--- a/Window.h
+++ b/Window.h
@@ -1,5 +1,4 @@
-#ifndef _WINDOW_H_
-#define _WINDOW_H_
+#pragma once
 
 #include <iostream>
 
@@ -23,5 +22,3 @@ public:
 	static void display_callback(GLFWwindow*);
 	static void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods);
 };
-
-#endif

--- a/main.cpp
+++ b/main.cpp
@@ -1,14 +1,12 @@
 #include "main.h"
 
-GLFWwindow* window;
-
 void error_callback(int error, const char* description)
 {
 	// Print error
 	fputs(description, stderr);
 }
 
-void setup_callbacks()
+void setup_callbacks(GLFWwindow* window)
 {
 	// Set the error callback
 	glfwSetErrorCallback(error_callback);
@@ -57,16 +55,16 @@ void setup_opengl_settings()
 	// Disable backface culling to render both sides of polygons
 	glDisable(GL_CULL_FACE);
 	// Set clear color to black
-	glClearColor(0.0, 0.0, 0.0, 0.0);                           
+	glClearColor(0.0, 0.0, 0.0, 0.0);
 	// Set shading to smooth
-	glShadeModel(GL_SMOOTH);                                    
+	glShadeModel(GL_SMOOTH);
 	// Auto normalize surface normals
 	glEnable(GL_NORMALIZE);
-	
+
 	// Setup materials
 	setup_materials();
 	// Setup lighting
-	setup_lighting();                                           
+	setup_lighting();
 }
 
 void print_versions()
@@ -84,11 +82,11 @@ void print_versions()
 int main(void)
 {
 	// Create the GLFW window
-	window = Window::create_window(640, 480);
+	GLFWwindow* window = Window::create_window(640, 480);
 	// Print OpenGL and GLSL versions
 	print_versions();
 	// Setup callbacks
-	setup_callbacks();
+	setup_callbacks(window);
 	// Setup OpenGL settings, including lighting, materials, etc.
 	setup_opengl_settings();
 	// Initialize objects/pointers for rendering

--- a/main.cpp
+++ b/main.cpp
@@ -13,7 +13,7 @@ void setup_callbacks(GLFWwindow* window)
 	// Set the key callback
 	glfwSetKeyCallback(window, Window::key_callback);
 	// Set the window resize callback
-	glfwSetWindowSizeCallback(window, Window::resize_callback);
+	glfwSetFramebufferSizeCallback(window, Window::resize_callback);
 }
 
 void setup_materials()

--- a/main.h
+++ b/main.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include <GL/glew.h>
+#ifdef __APPLE__
 #include <OpenGL/gl3.h>
+#else
+#include <OpenGL/gl.h>
+#endif /* __APPLE__ */
 #include <OpenGL/glext.h>
 
 #include <GLFW/glfw3.h>

--- a/main.h
+++ b/main.h
@@ -1,5 +1,4 @@
-#ifndef _MAIN_H_
-#define _MAIN_H_
+#pragma once
 
 #include <GL/glew.h>
 #include <OpenGL/gl3.h>
@@ -9,5 +8,3 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "Window.h"
-
-#endif

--- a/main.h
+++ b/main.h
@@ -1,13 +1,10 @@
 #ifndef _MAIN_H_
 #define _MAIN_H_
 
-#ifdef __APPLE__
-// If modern OpenGL replace gl.h with gl3.h
-#include <OpenGL/gl.h>
-#include <OpenGL/glext.h>
-#else
 #include <GL/glew.h>
-#endif
+#include <OpenGL/gl3.h>
+#include <OpenGL/glext.h>
+
 #include <GLFW/glfw3.h>
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
Depends on PR #1 
Fix for high DPI displays. Use `glfwGetFramebufferSize` to set the framebuffer size, rather than window size, as FB pixels are not 1:1 with window pixels on HDPI displays. 
